### PR TITLE
Add .cxx file to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ lib/generated_plugin_registrant.dart
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 
 ios/build
+android/app/.cxx


### PR DESCRIPTION
These files are too noisy while testing or debugging the app , so adding it to the .gitignore.
